### PR TITLE
ISSUE#24 Fix signed in as top right

### DIFF
--- a/Theme.css
+++ b/Theme.css
@@ -7348,3 +7348,7 @@ input {
 .container-preview .tabnav-tabs .selected {
     background: none !important;
 }
+
+.header-nav-current-user .user-profile-link {
+    color: #4299fc;
+}


### PR DESCRIPTION
https://github.com/acoop133/GithubDarkTheme/issues/24

Somehow this issue was resolved, but i one upped it and fixed the signed in as link colour so it is no longer invisible
.
![image](https://user-images.githubusercontent.com/19627023/56995188-f02a0f00-6b98-11e9-836c-ac450d4b245c.png)
