### PR TITLE
ISSUE#44 Hard to see btn + last of type box-row fix

### DIFF
--- a/Theme.css
+++ b/Theme.css
@@ -7451,6 +7451,10 @@ header.container-xl.px-3.px-md-6.py-3.position-relative.d-flex.flex-justify-betw
     border: 1px solid #484848 !important;
 }
 
+.btn {
+    border: 1px solid !important;
+}
+
 .btn-danger {
     background: #3e1a1a !important;
 }

--- a/Theme.css
+++ b/Theme.css
@@ -7458,3 +7458,10 @@ header.container-xl.px-3.px-md-6.py-3.position-relative.d-flex.flex-justify-betw
 .btn-danger {
     background: #3e1a1a !important;
 }
+
+.Box-row:last-of-type {
+    border-bottom-left-radius: unset;
+    border-bottom-right-radius: unset;
+    padding-bottom: 1px !important;
+    border-bottom: 1px solid #343434 !important;
+}

--- a/Theme.css
+++ b/Theme.css
@@ -7450,3 +7450,7 @@ header.container-xl.px-3.px-md-6.py-3.position-relative.d-flex.flex-justify-betw
     background-color: transparent !important;
     border: 1px solid #484848 !important;
 }
+
+.btn-danger {
+    background: #3e1a1a !important;
+}


### PR DESCRIPTION
https://github.com/acoop133/GithubDarkTheme/issues/44

Danger Btn background
![image](https://user-images.githubusercontent.com/19627023/59983774-91729600-961b-11e9-9781-34ef5f10a384.png)

Btn border
![image](https://user-images.githubusercontent.com/19627023/59983805-a51dfc80-961b-11e9-85de-75d8c0bb92a7.png)

Last of type box-row fix
before
![image](https://user-images.githubusercontent.com/19627023/59983840-d0a0e700-961b-11e9-9176-6da2a0c14a46.png)

after
![image](https://user-images.githubusercontent.com/19627023/59983829-bd8e1700-961b-11e9-8396-04784e8613ec.png)
