### PR TITLE
remove border, btn background is lighter

### DIFF
--- a/Theme.css
+++ b/Theme.css
@@ -7451,8 +7451,13 @@ header.container-xl.px-3.px-md-6.py-3.position-relative.d-flex.flex-justify-betw
     border: 1px solid #484848 !important;
 }
 
-.btn {
-    border: 1px solid !important;
+.btn,
+a.btn {
+    background: #353535 !important;
+}
+
+.pagehead-actions .btn-sm {
+    background: #24292e !important;
 }
 
 .btn-danger {


### PR DESCRIPTION
Updated fix for https://github.com/acoop133/GithubDarkTheme/issues/44  didnt like the border that much

![image](https://user-images.githubusercontent.com/19627023/59984262-1bbcf900-9620-11e9-9377-71e2da12b7d5.png)

![image](https://user-images.githubusercontent.com/19627023/59984276-342d1380-9620-11e9-8133-3a7182a99fad.png)

![image](https://user-images.githubusercontent.com/19627023/59984289-47d87a00-9620-11e9-9526-c270d05a8544.png)

![image](https://user-images.githubusercontent.com/19627023/59984298-69d1fc80-9620-11e9-8293-c0675137932f.png)
