### PR TITLE
Lighten colour of discussion/commit timeline

### DIFF
--- a/Theme.css
+++ b/Theme.css
@@ -1467,7 +1467,6 @@ ul.color-label-list .color,
 
 .discussion-timeline:before {
     margin-top: 2px !important;
-    background: #383838 !important;
     height: calc(100% - 259px) !important;
 }
 
@@ -7538,6 +7537,7 @@ a.btn,
 }
 
 .commits-listing:before,
+.discussion-timeline:before,
 .discussion-item-icon {
     background: #555;
 }

--- a/Theme.css
+++ b/Theme.css
@@ -2197,15 +2197,12 @@ table.instruction tr:nth-child(2n),
 .pull-head .diffstat,
 ul.suggestions,
 .discusion-topic-infobar,
-.commits-listing:before,
-.discussion-item-icon,
 .jstree-wholerow-hovered,
 .bubble-contents,
 .ellipsis-button,
 .filter-list li span.bar,
 .selectable_day.today,
 .billing-plans .current,
-.commits-listing:before,
 .billing-section .usage-bar,
 .issue-list em,
 .file-info-divider,
@@ -7538,4 +7535,9 @@ a.btn,
 
 .user-status-container-border-busy {
     background-color: #bd4a29 !important;
+}
+
+.commits-listing:before,
+.discussion-item-icon {
+    background: #666;
 }

--- a/Theme.css
+++ b/Theme.css
@@ -7539,5 +7539,5 @@ a.btn,
 
 .commits-listing:before,
 .discussion-item-icon {
-    background: #666;
+    background: #555;
 }


### PR DESCRIPTION
Before: ![image](https://user-images.githubusercontent.com/26777129/60773473-ce0bba80-a10e-11e9-9905-ce1403466657.png) After: ![image](https://user-images.githubusercontent.com/26777129/60773561-18416b80-a110-11e9-8c57-b287fddc189b.png)
