### PR TITLE
Make empty calendar-graph squares visible

### DIFF
--- a/Theme.css
+++ b/Theme.css
@@ -2336,8 +2336,8 @@ ul.fieldpills li,
 
 .calendar-graph rect[fill="#ebedf0"],
 .contrib-legend li[style*="#ebedf0"] {
-    background-color: #222 !important;
-    fill: #222 !important;
+    background-color: #2b2b2b !important;
+    fill: #2b2b2b !important;
 }
 
 .heat[data-heat="1"],


### PR DESCRIPTION
The empty calendar-graph squares were set to #222, the same color as the background, so they aren't visible. It appears better to have the empty squares slightly visible in a calendar-graph table.