### PR TITLE
Update reactions' buttons color

### DIFF
--- a/Theme.css
+++ b/Theme.css
@@ -3765,7 +3765,8 @@ table.capped-list .octicon,
 a.exploregrid-item,
 .markdown-body blockquote,
 .link-gray,
-a.link-gray {
+a.link-gray,
+.reaction-summary-item {
     color: #b5b5b5 !important;
 }
 

--- a/Theme.css
+++ b/Theme.css
@@ -388,14 +388,6 @@ div[id^="contribution-joined-github"] img {
     width: calc(100% - 94px) !important;
 }
 
-.comment-reactions .user-has-reacted {
-    color: #8195be !important;
-}
-
-.comment-reactions .user-has-reacted:hover {
-    color: #a1b5de !important;
-}
-
 
 /* HACK: Label colors */
 
@@ -7619,4 +7611,12 @@ button.btn-link.link-gray.js-details-target {
 div[style="background-color: #fcfdfd;"],
 .MarketplaceBackground-buffer {
     background: #25272a !important;
+}
+
+.comment-reactions .user-has-reacted {
+    color: #a8c4fd !important;
+}
+
+.comment-reactions .user-has-reacted:hover {
+    color: #ffffff !important;
 }


### PR DESCRIPTION
It was pretty dark blue that was hard to see, added it after `.link-gray` to match the buttons' color in `.timeline-comment-actions`.

Before: 
![image](https://user-images.githubusercontent.com/26777129/64990369-5ad5b000-d8d8-11e9-8749-77c98a34fef5.png)
After: 
![image](https://user-images.githubusercontent.com/26777129/64990646-dc2d4280-d8d8-11e9-8af7-4a864bf10c67.png)